### PR TITLE
quickfix: project name in dune

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
 (lang dune 2.0)
-(name http-client)
+(name httpcats)


### PR DESCRIPTION
Hello 🐱,

Just a quickfix of the project name in `dune`. The old name makes the build fail otherwise…

Cheers,
– Chouhartem