### PR TITLE
Expose server_connection functions to user

### DIFF
--- a/app/main.ml
+++ b/app/main.ml
@@ -49,8 +49,11 @@ let unicast_censurfridns_dk =
 let () =
   Miou_unix.run @@ fun () ->
   let daemon, resolver = Happy_eyeballs_miou_unix.make () in
-  let dns = Dns_client_miou_unix.create ~nameservers:(`Udp, [ google ]) resolver in
-  Happy_eyeballs_miou_unix.inject_resolver ~getaddrinfo:(getaddrinfo dns) resolver;
+  let dns =
+    Dns_client_miou_unix.create ~nameservers:(`Udp, [ google ]) resolver
+  in
+  Happy_eyeballs_miou_unix.inject_resolver ~getaddrinfo:(getaddrinfo dns)
+    resolver;
   let f _resp buf str = Buffer.add_string buf str; buf in
   match
     Httpcats.request ~resolver ~f ~uri:Sys.argv.(1) (Buffer.create 0x100)

--- a/app/pars.ml
+++ b/app/pars.ml
@@ -253,7 +253,8 @@ let () =
     (`Udp, [ `Plaintext (Ipaddr.of_string_exn "8.8.8.8", 53) ])
   in
   let dns = Dns_client_miou_unix.create ~nameservers resolver in
-  Happy_eyeballs_miou_unix.inject_resolver ~getaddrinfo:(getaddrinfo dns) resolver;
+  Happy_eyeballs_miou_unix.inject_resolver ~getaddrinfo:(getaddrinfo dns)
+    resolver;
   let t = make ~resolver ~filenames in
   let prm = Miou.call_cc (run t uris) in
   let result = Miou.await prm in

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -80,28 +80,26 @@ let rec cleanup orphans =
   | None | Some None -> ()
   | Some (Some prm) -> Miou.await_exn prm; cleanup orphans
 
-let handler = function
-  | `V2 _ -> assert false
-  | `V1 reqd -> (
-      let open Httpaf in
-      let request = Reqd.request reqd in
-      match request.Request.target with
-      | "" | "/" | "/index.html" ->
-          let headers =
-            Headers.of_list
-              [
-                ("content-type", "text/html; charset=utf-8")
-              ; ("content-length", string_of_int (String.length index_html))
-              ]
-          in
-          let resp = Response.create ~headers `OK in
-          let body = Reqd.request_body reqd in
-          Body.close_reader body;
-          Reqd.respond_with_string reqd resp index_html
-      | _ ->
-          let headers = Headers.of_list [ ("content-length", "0") ] in
-          let resp = Response.create ~headers `Not_found in
-          Reqd.respond_with_string reqd resp "")
+let handler reqd =
+  let open Httpaf in
+  let request = Reqd.request reqd in
+  match request.Request.target with
+  | "" | "/" | "/index.html" ->
+      let headers =
+        Headers.of_list
+          [
+            ("content-type", "text/html; charset=utf-8")
+          ; ("content-length", string_of_int (String.length index_html))
+          ]
+      in
+      let resp = Response.create ~headers `OK in
+      let body = Reqd.request_body reqd in
+      Body.close_reader body;
+      Reqd.respond_with_string reqd resp index_html
+  | _ ->
+      let headers = Headers.of_list [ ("content-length", "0") ] in
+      let resp = Response.create ~headers `Not_found in
+      Reqd.respond_with_string reqd resp ""
 
 let server sockaddr = Httpcats.Server.clear ~handler sockaddr
 let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore

--- a/httpcats.opam
+++ b/httpcats.opam
@@ -32,7 +32,7 @@ build: [
 
 synopsis: "A simple HTTP client using http/af, h2, and miou"
 pin-depends: [
-  [ "miou.dev" "git+https://git.robur.coop/robur/miou.git#ed5087b832797616df073bd8ec9baed2ec4e474c" ]
+  [ "miou.dev" "git+https://github.com/robur-coop/miou.git#ed5087b832797616df073bd8ec9baed2ec4e474c" ]
   [ "mirage-crypto.0.11.3" "git+https://github.com/dinosaure/mirage-crypto.git#c0e29117be2d081b50a5f1a789b16c77585324a3" ]
   [ "mirage-crypto-rng.0.11.3" "git+https://github.com/dinosaure/mirage-crypto.git#c0e29117be2d081b50a5f1a789b16c77585324a3" ]
   [ "alcotest.1.7.0" "git+https://github.com/dinosaure/alcotest.git#d591896a54ff4f652ac2d7d7194de1e0fb6e3aca" ]

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,5 @@
  (public_name httpcats)
  (modules httpcats http_miou_unix http_miou_client http_miou_server flow
    runtime)
- (libraries hxd.string hxd.core ca-certs happy-eyeballs-miou-unix dns-client-miou-unix
-   httpaf h2 tls-miou-unix))
+ (libraries hxd.string hxd.core ca-certs happy-eyeballs-miou-unix
+   dns-client-miou-unix httpaf h2 tls-miou-unix))

--- a/src/http_miou_server.mli
+++ b/src/http_miou_server.mli
@@ -24,13 +24,34 @@ type reqd = [ `V1 of Httpaf.Reqd.t | `V2 of H2.Reqd.t ]
 type error_handler = ?request:request -> error -> (Headers.t -> body) -> unit
 type handler = reqd -> unit
 
+val http_1_1_server_connection :
+     ?config:Httpaf.Config.t
+  -> ?error_handler:error_handler
+  -> handler:(Httpaf.Reqd.t -> unit)
+  -> Miou_unix.file_descr
+  -> unit
+
 val clear :
      ?stop:stop
   -> ?config:Httpaf.Config.t
   -> ?backlog:int
   -> ?error_handler:error_handler
-  -> handler:handler
+  -> handler:(Httpaf.Reqd.t -> unit)
   -> Unix.sockaddr
+  -> unit
+
+val https_1_1_server_connection :
+     ?config:Httpaf.Config.t
+  -> ?error_handler:error_handler
+  -> handler:(Httpaf.Reqd.t -> unit)
+  -> Tls_miou_unix.t
+  -> unit
+
+val h2s_server_connection :
+     ?config:H2.Config.t
+  -> ?error_handler:error_handler
+  -> handler:(H2.Reqd.t -> unit)
+  -> Tls_miou_unix.t
   -> unit
 
 val with_tls :


### PR DESCRIPTION
This allows for the user to use httpcats while writing their own server loop, which is essential for a number of usecases including parsing of the tcp PROXY protocol or custom logging code/logic that must run before a request is parsed. There is also a small change to the signature of handlers to avoid an `assert false` when H2 is impossible.