### PR TITLE
Don't predate the Flow.close when we get an error from the system

### DIFF
--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -140,7 +140,7 @@ module Make (Flow : Flow.S) (Runtime : S) = struct
     in
     try List.iter fn bstrs; `Ok len with
     | Closed_by_peer -> `Closed
-    | _exn -> Flow.close flow; `Closed
+    | _exn -> `Closed
 
   type t = {
       tags: Logs.Tag.set


### PR DESCRIPTION
If we do that, the next `Flow.close` (handled by `Miou.Ownership`) will finish with an exception. Globally, we are sure, by the Ownership mechanism, that our resources are closed properly.