### PR TITLE
allow httpcats to serve a unix-domain socket

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -133,7 +133,7 @@ let upgrade flow =
   Httpcats.Server.Websocket.upgrade ~fn (`Tcp flow)
 
 let server stop sockaddr =
-  Httpcats.Server.clear ~stop ~handler ~upgrade sockaddr
+  Httpcats.Server.clear ~stop ~handler ~upgrade (Httpcats.Server.Bind sockaddr)
 
 (*let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore*)
 

--- a/examples/static.ml
+++ b/examples/static.ml
@@ -105,7 +105,7 @@ let[@warning "-8"] handler ~root _
 
 let server (root, sockaddr) =
   let handler = handler ~root in
-  Httpcats.Server.clear ~handler sockaddr
+  Httpcats.Server.(clear ~handler (Bind sockaddr))
 
 let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore
 

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -131,7 +131,7 @@ let default_error_handler version ?request:_ err respond =
 let pp_sockaddr ppf = function
   | Unix.ADDR_INET (inet_addr, port) ->
       Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr inet_addr) port
-  | Unix.ADDR_UNIX str -> Fmt.pf ppf "<%s>" str
+  | Unix.ADDR_UNIX str -> Fmt.pf ppf "<unix:%s>" str
 
 let http_1_1_server_connection ~config ~user's_error_handler ?upgrade
     ~user's_handler flow =

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -300,7 +300,7 @@ let socket_spec_to_fd backlog = function
       let fd =
         let open Unix in
         match sockaddr with
-        | ADDR_UNIX _ -> failwith "impossible to create a UNIX socket!"
+        | ADDR_UNIX _ -> Miou_unix.unix_socket ()
         | ADDR_INET (inet_addr, _) ->
             if is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
             else Miou_unix.tcpv4 ()

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -295,20 +295,19 @@ let pp_sockaddr ppf = function
 let inhibit fn = try fn () with _exn -> ()
 
 let socket_spec_to_fd backlog = function
-  | Use (fd, sockaddr) -> fd, sockaddr
+  | Use (fd, sockaddr) -> (fd, sockaddr)
   | Bind sockaddr ->
-     let fd =
-       let open Unix in
-       match sockaddr with
-       | ADDR_UNIX _ ->
-          failwith "impossible to create a UNIX socket!"
-       | ADDR_INET (inet_addr, _) ->
-          if is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
-          else Miou_unix.tcpv4 ()
-     in
-     Log.debug (fun m -> m "binding fd %a to %a" pp_fd fd pp_sockaddr sockaddr);
-     Miou_unix.bind_and_listen ?backlog fd sockaddr;
-     fd, sockaddr
+      let fd =
+        let open Unix in
+        match sockaddr with
+        | ADDR_UNIX _ -> failwith "impossible to create a UNIX socket!"
+        | ADDR_INET (inet_addr, _) ->
+            if is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
+            else Miou_unix.tcpv4 ()
+      in
+      Log.debug (fun m -> m "binding fd %a to %a" pp_fd fd pp_sockaddr sockaddr);
+      Miou_unix.bind_and_listen ?backlog fd sockaddr;
+      (fd, sockaddr)
 
 let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) ?upgrade
@@ -326,7 +325,8 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Miou.yield ();
         go orphans file_descr server'sockaddr
     | None ->
-        Log.debug (fun m -> m "stop the server on %a" pp_sockaddr server'sockaddr);
+        Log.debug (fun m ->
+            m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
         Miou_unix.close file_descr
     | Some (fd', client'sockaddr) ->
@@ -371,10 +371,11 @@ let with_tls ?(parallel = true) ?stop
         Miou.yield ();
         go orphans file_descr server'sockaddr
     | None ->
-       Runtime.terminate orphans;
-       Miou_unix.close file_descr;
-       Log.debug (fun m -> m "Stopping service on fd %a, %a"
-         pp_fd file_descr pp_sockaddr server'sockaddr)
+        Runtime.terminate orphans;
+        Miou_unix.close file_descr;
+        Log.debug (fun m ->
+            m "Stopping service on fd %a, %a" pp_fd file_descr pp_sockaddr
+              server'sockaddr)
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);
@@ -383,8 +384,9 @@ let with_tls ?(parallel = true) ?stop
             let tls_flow = Tls_miou_unix.server_of_fd tls_config fd' in
             begin match (config, alpn tls_flow) with
             | `Both (_, h2), Some "h2" | `H2 h2, (Some "h2" | None) ->
-               Log.debug (fun m -> m "Start a h2 request handler on fd %a for %a"
-                 pp_fd fd' pp_sockaddr client'sockaddr);
+                Log.debug (fun m ->
+                    m "Start a h2 request handler on fd %a for %a" pp_fd fd'
+                      pp_sockaddr client'sockaddr);
                 h2s_server_connection ~config:h2 ~user's_error_handler ?upgrade
                   ~user's_handler tls_flow
             | `Both (config, _), Some "http/1.1"
@@ -403,11 +405,13 @@ let with_tls ?(parallel = true) ?stop
                   (Printexc.to_string exn));
             Miou_unix.close fd'
         in
-        call ~orphans fn; go orphans file_descr server'sockaddr
+        call ~orphans fn;
+        go orphans file_descr server'sockaddr
   in
   let socket, server'sockaddr = socket_spec_to_fd backlog socket_spec in
-  Log.debug (fun m -> m "Starting service for fd %a, %a"
-                        pp_fd socket pp_sockaddr server'sockaddr);
+  Log.debug (fun m ->
+      m "Starting service for fd %a, %a" pp_fd socket pp_sockaddr
+        server'sockaddr);
   Option.iter (fun c -> ignore (Miou.Computation.try_return c ())) ready;
   go (Miou.orphans ()) socket server'sockaddr
 

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -326,14 +326,14 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Miou.yield ();
         go orphans file_descr server'sockaddr
     | None ->
-        Log.debug (fun m -> m "stop the server");
+        Log.debug (fun m -> m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
         Miou_unix.close file_descr
-    | Some (fd', sockaddr) ->
+    | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);
         Log.debug (fun m ->
-            m "receive a connection from: %a" pp_sockaddr sockaddr);
+            m "receive a connection from: %a" pp_sockaddr client'sockaddr);
         call ~orphans begin fun () ->
             http_1_1_server_connection ~config ~user's_error_handler ?upgrade
               ~user's_handler fd'
@@ -383,7 +383,8 @@ let with_tls ?(parallel = true) ?stop
             let tls_flow = Tls_miou_unix.server_of_fd tls_config fd' in
             begin match (config, alpn tls_flow) with
             | `Both (_, h2), Some "h2" | `H2 h2, (Some "h2" | None) ->
-                Log.debug (fun m -> m "Start a h2 request handler");
+               Log.debug (fun m -> m "Start a h2 request handler on fd %a for %a"
+                 pp_fd fd' pp_sockaddr client'sockaddr);
                 h2s_server_connection ~config:h2 ~user's_error_handler ?upgrade
                   ~user's_handler tls_flow
             | `Both (config, _), Some "http/1.1"

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -72,6 +72,11 @@ type response = Httpcats_core.Server.response = {
 
 type body = [ `V1 of H1.Body.Writer.t | `V2 of H2.Body.Writer.t ]
 type reqd = [ `V1 of H1.Reqd.t | `V2 of H2.Reqd.t ]
+
+type socket_spec =
+  | Use of Miou_unix.file_descr * Unix.sockaddr
+  | Bind of Unix.sockaddr
+
 type error_handler = Httpcats_core.Server.error_handler
 
 type handler =
@@ -277,6 +282,11 @@ let accept_or_stop ?stop file_descr =
             raise exn
     end
 
+let pp_fd ppf miou_fd =
+  let fd' = Miou_unix.to_file_descr miou_fd in
+  let fd : int = Obj.magic fd' in
+  Fmt.pf ppf "%d" fd
+
 let pp_sockaddr ppf = function
   | Unix.ADDR_UNIX str -> Fmt.pf ppf "<%s>" str
   | Unix.ADDR_INET (inet_addr, port) ->
@@ -284,21 +294,37 @@ let pp_sockaddr ppf = function
 
 let inhibit fn = try fn () with _exn -> ()
 
+let socket_spec_to_fd backlog = function
+  | Use (fd, sockaddr) -> fd, sockaddr
+  | Bind sockaddr ->
+     let fd =
+       let open Unix in
+       match sockaddr with
+       | ADDR_UNIX _ ->
+          failwith "impossible to create a UNIX socket!"
+       | ADDR_INET (inet_addr, _) ->
+          if is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
+          else Miou_unix.tcpv4 ()
+     in
+     Log.debug (fun m -> m "binding fd %a to %a" pp_fd fd pp_sockaddr sockaddr);
+     Miou_unix.bind_and_listen ?backlog fd sockaddr;
+     fd, sockaddr
+
 let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) ?upgrade
-    ~handler:user's_handler sockaddr =
+    ~handler:user's_handler socket_spec =
   let domains = Miou.Domain.available () in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
     else ignore (Miou.async ~orphans fn)
   in
-  let rec go orphans file_descr =
+  let rec go orphans file_descr server'sockaddr =
     clean_up orphans;
     match accept_or_stop ?stop file_descr with
     | exception Unix.Unix_error ((Unix.EMFILE | Unix.ENFILE), _, _) ->
         Log.warn (fun m -> m "too many open files, backing off");
         Miou.yield ();
-        go orphans file_descr
+        go orphans file_descr server'sockaddr
     | None ->
         Log.debug (fun m -> m "stop the server");
         Runtime.terminate orphans;
@@ -312,18 +338,11 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
             http_1_1_server_connection ~config ~user's_error_handler ?upgrade
               ~user's_handler fd'
           end;
-        go orphans file_descr
+        go orphans file_descr server'sockaddr
   in
-  let socket =
-    match sockaddr with
-    | Unix.ADDR_UNIX _ -> invalid_arg "Impossible to create a Unix socket"
-    | Unix.ADDR_INET (inet_addr, _) ->
-        if Unix.is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
-        else Miou_unix.tcpv4 ()
-  in
-  Miou_unix.bind_and_listen ?backlog socket sockaddr;
+  let socket, server'sockaddr = socket_spec_to_fd backlog socket_spec in
   Option.iter (fun c -> ignore (Miou.Computation.try_return c ())) ready;
-  go (Miou.orphans ()) socket
+  go (Miou.orphans ()) socket server'sockaddr
 
 let alpn tls =
   match Tls_miou_unix.epoch tls with
@@ -338,21 +357,25 @@ let alpn tls =
 let with_tls ?(parallel = true) ?stop
     ?(config = `Both (H1.Config.default, H2.Config.default)) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) tls_config
-    ?upgrade ~handler:user's_handler sockaddr =
+    ?upgrade ~handler:user's_handler socket_spec =
   let domains = Miou.Domain.available () in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
     else ignore (Miou.async ~orphans fn)
   in
-  let rec go orphans file_descr =
+  let rec go orphans file_descr server'sockaddr =
     clean_up orphans;
     match accept_or_stop ?stop file_descr with
     | exception Unix.Unix_error ((Unix.EMFILE | Unix.ENFILE), _, _) ->
         Log.warn (fun m -> m "too many open files, backing off");
         Miou.yield ();
-        go orphans file_descr
-    | None -> Runtime.terminate orphans; Miou_unix.close file_descr
-    | Some (fd', _sockaddr) ->
+        go orphans file_descr server'sockaddr
+    | None ->
+       Runtime.terminate orphans;
+       Miou_unix.close file_descr;
+       Log.debug (fun m -> m "Stopping service on fd %a, %a"
+         pp_fd file_descr pp_sockaddr server'sockaddr)
+    | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);
         let fn () =
@@ -379,18 +402,13 @@ let with_tls ?(parallel = true) ?stop
                   (Printexc.to_string exn));
             Miou_unix.close fd'
         in
-        call ~orphans fn; go orphans file_descr
+        call ~orphans fn; go orphans file_descr server'sockaddr
   in
-  let socket =
-    match sockaddr with
-    | Unix.ADDR_UNIX _ -> invalid_arg "Impossible to create a Unix socket"
-    | Unix.ADDR_INET (inet_addr, _) ->
-        if Unix.is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
-        else Miou_unix.tcpv4 ()
-  in
-  Miou_unix.bind_and_listen ?backlog socket sockaddr;
+  let socket, server'sockaddr = socket_spec_to_fd backlog socket_spec in
+  Log.debug (fun m -> m "Starting service for fd %a, %a"
+                        pp_fd socket pp_sockaddr server'sockaddr);
   Option.iter (fun c -> ignore (Miou.Computation.try_return c ())) ready;
-  go (Miou.orphans ()) socket
+  go (Miou.orphans ()) socket server'sockaddr
 
 module Websocket_connection = struct
   (* make it match Runtime.S signature *)

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -49,6 +49,16 @@ let pp_error ppf = function
   | `V2 `Bad_request -> Fmt.string ppf "Bad H2 request"
   | `Protocol msg -> Fmt.string ppf msg
 
+let pp_fd ppf miou_fd =
+  let fd' = Miou_unix.to_file_descr miou_fd in
+  let fd : int = Obj.magic fd' in
+  Fmt.pf ppf "%d" fd
+
+let pp_sockaddr ppf = function
+  | Unix.ADDR_INET (inet_addr, port) ->
+      Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr inet_addr) port
+  | Unix.ADDR_UNIX s -> Fmt.pf ppf "<unix:%s>" s
+
 let src = Logs.Src.create "http-miou-server"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -127,11 +137,6 @@ let default_error_handler version ?request:_ err respond =
       in
       Log.debug (fun m -> m "flush the errored h2 response");
       H2.Body.Writer.flush body fn
-
-let pp_sockaddr ppf = function
-  | Unix.ADDR_INET (inet_addr, port) ->
-      Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr inet_addr) port
-  | Unix.ADDR_UNIX str -> Fmt.pf ppf "<unix:%s>" str
 
 let http_1_1_server_connection ~config ~user's_error_handler ?upgrade
     ~user's_handler flow =
@@ -270,7 +275,7 @@ let accept_or_stop ?stop file_descr =
       else
         let accept = Miou.async @@ fun () -> Miou_unix.accept file_descr in
         let stop = Miou.async (wait s) in
-        Log.debug (fun m -> m "waiting for a client");
+        Log.debug (fun m -> m "waiting for a client on fd %a" pp_fd file_descr);
         match Miou.await_first [ accept; stop ] with
         | Ok (fd, _sockaddr) when Atomic.get s.flag -> Miou_unix.close fd; None
         | Ok (fd, sockaddr) -> Some (fd, sockaddr)
@@ -333,7 +338,8 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);
         Log.debug (fun m ->
-            m "receive a connection from: %a" pp_sockaddr client'sockaddr);
+            m "receive a connection on fd %a from: %a" pp_fd fd' pp_sockaddr
+              client'sockaddr);
         call ~orphans begin fun () ->
             http_1_1_server_connection ~config ~user's_error_handler ?upgrade
               ~user's_handler fd'

--- a/src/http_miou_server.mli
+++ b/src/http_miou_server.mli
@@ -34,7 +34,8 @@ val switch : stop -> unit
 
 type flow = [ `Tls of Tls_miou_unix.t | `Tcp of Miou_unix.file_descr ]
 (** The type of connection used to communicate with the client — whether the
-    connection is secure ([`Tls]) or not ([`Tcp]). *)
+    connection is secure ([`Tls]) or not ([`Tcp]). Note that [`Tcp] connections
+    may in fact come from a UNIX-domain socket; the name is historical. *)
 
 type request = {
     meth: Method.t
@@ -92,7 +93,7 @@ type handler = flow -> reqd -> unit
         let stop = Httpcats.Server.stop () in
         let fn _sigint = Httpcats.Server.switch stop in
         ignore (Miou.sys_signal Sys.sigint (Sys.Signal_handle fn));
-        Httpcats.Server.clear ~stop ~handler sockaddr
+        Httpcats.Server.(clear ~stop ~handler (Bind sockaddr))
     ]}
 
     {2:ready Ready state of the server}

--- a/src/http_miou_server.mli
+++ b/src/http_miou_server.mli
@@ -56,9 +56,9 @@ type reqd = [ `V1 of H1.Reqd.t | `V2 of H2.Reqd.t ]
 type socket_spec =
   | Use of Miou_unix.file_descr * Unix.sockaddr
   | Bind of Unix.sockaddr
-(** Controls whether or not [httpcats] binds its own socket or handles the file
-    descriptor it was handed. In the former case, the provided {!Unix.sockaddr}
-    is only used for logging. *)
+      (** Controls whether or not [httpcats] binds its own socket or handles the
+          file descriptor it was handed. In the former case, the provided
+          {!Unix.sockaddr} is only used for logging. *)
 
 type error_handler =
   [ `V1 | `V2 ] -> ?request:request -> error -> (Headers.t -> body) -> unit

--- a/src/http_miou_server.mli
+++ b/src/http_miou_server.mli
@@ -52,6 +52,13 @@ type response = { status: Status.t; headers: Headers.t }
 type body = [ `V1 of H1.Body.Writer.t | `V2 of H2.Body.Writer.t ]
 type reqd = [ `V1 of H1.Reqd.t | `V2 of H2.Reqd.t ]
 
+type socket_spec =
+  | Use of Miou_unix.file_descr * Unix.sockaddr
+  | Bind of Unix.sockaddr
+(** Controls whether or not [httpcats] binds its own socket or handles the file
+    descriptor it was handed. In the former case, the provided {!Unix.sockaddr}
+    is only used for logging. *)
+
 type error_handler =
   [ `V1 | `V2 ] -> ?request:request -> error -> (Headers.t -> body) -> unit
 
@@ -136,7 +143,7 @@ val clear :
   -> ?error_handler:error_handler
   -> ?upgrade:(Miou_unix.file_descr -> unit)
   -> handler:handler
-  -> Unix.sockaddr
+  -> socket_spec
   -> unit
 
 val with_tls :
@@ -152,7 +159,7 @@ val with_tls :
   -> Tls.Config.server
   -> ?upgrade:(Tls_miou_unix.t -> unit)
   -> handler:handler
-  -> Unix.sockaddr
+  -> socket_spec
   -> unit
 
 module Websocket : sig

--- a/test/test.ml
+++ b/test/test.ml
@@ -32,7 +32,8 @@ let server ?(port = 9451) handler =
     Miou.async @@ fun () ->
     let any = Unix.inet_addr_of_string "0.0.0.0" in
     let sockaddr = Unix.ADDR_INET (any, port) in
-    Httpcats.Server.clear ~stop ~handler sockaddr
+    let socket_spec = Httpcats.Server.Bind sockaddr in
+    Httpcats.Server.clear ~stop ~handler socket_spec
   in
   (stop, prm)
 
@@ -104,13 +105,14 @@ let secure_server ~seed ?(port = 8080) handler =
     Miou.async @@ fun () ->
     let any = Unix.inet_addr_of_string "0.0.0.0" in
     let sockaddr = Unix.ADDR_INET (any, port) in
+    let socket_spec = Httpcats.Server.Bind sockaddr in
     let cfg =
       Tls.Config.server
         ~certificates:(`Single ([ cert ], pk))
         ~alpn_protocols:[ "h2"; "http/1.1" ] ()
       |> Result.get_ok
     in
-    Httpcats.Server.with_tls ~stop cfg ~handler sockaddr
+    Httpcats.Server.with_tls ~stop cfg ~handler socket_spec
   in
   (stop, prm, authenticator)
 


### PR DESCRIPTION
tested with our miou patch and a basic 404 handler and `curl --unix-domain`

    let handler flow (`V1 req:Httpcats.Server.reqd) =
      let open H1 in
      let headers = Headers.of_list [ ("content-length", "0") ] in
      let resp = Response.create ~headers `Not_found in
      Reqd.respond_with_string req resp ""
    in
    Miou_unix.run @@ fun () ->
      let stop = Httpcats.Server.stop () in
      let sig' _ = Httpcats.Server.switch stop in
      let open Sys in
      List.iter
        (fun s -> ignore (Miou.sys_signal s @@ Signal_handle sig'))
        [ sighup ; sigint ; sigterm ; sigabrt ];
      Httpcats.Server.clear ~parallel:true ~stop ~handler (Unix.ADDR_UNIX "socket")