### PR TITLE
inhibit EBADF during close

### DIFF
--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -309,6 +309,7 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) ?upgrade
     ~handler:user's_handler listen =
   let domains = Miou.Domain.available () in
+  let closed = Atomic.make false in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
     else ignore (Miou.async ~orphans fn)
@@ -324,8 +325,8 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Log.debug (fun m ->
             m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        try Miou_unix.close file_descr
-        with Unix.(Unix_error (EBADF, _, _)) -> ()
+        if Atomic.compare_and_set closed false true then
+          Miou_unix.close file_descr
       end
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -320,11 +320,13 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Log.warn (fun m -> m "too many open files, backing off");
         Miou.yield ();
         go orphans file_descr server'sockaddr
-    | None ->
+    | None -> begin
         Log.debug (fun m ->
             m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        Miou_unix.close file_descr
+        try Miou_unix.close file_descr
+        with Unix.(Unix_error (EBADF, _, _)) -> ()
+      end
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);


### PR DESCRIPTION
When `Use`—ing a socket for the listener, shutting down the server will throw this exception because the domains all race to close the same socket, but only one wins. Since it's shutting down anyway, and at least one domain will have closed it, we can ignore EBADF.