### PR TITLE
Fix infinite `terminate`

### DIFF
--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -10,7 +10,7 @@ module TCP_and_H1 = struct
      as soon as the process has finished, we close the socket.
 
      See [http_1_1_server_connection] for the [Unix.close]. *)
-  let shutdown flow = function `read -> () | value -> shutdown flow value
+  let shutdown flow = function `read | `read_write -> () | value -> shutdown flow value
 end
 
 module H2_Server_connection = struct

--- a/src/http_miou_unix.ml
+++ b/src/http_miou_unix.ml
@@ -23,7 +23,7 @@ module TCP = struct
     try match cmd with
       | `read -> Unix.shutdown (Miou_unix.to_file_descr flow) Unix.SHUTDOWN_RECEIVE
       | `write -> Unix.shutdown (Miou_unix.to_file_descr flow) Unix.SHUTDOWN_SEND
-      | `read_write -> Unix.close (Miou_unix.to_file_descr flow)
+      | `read_write -> Unix.shutdown (Miou_unix.to_file_descr flow) Unix.SHUTDOWN_ALL
     with Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
   [@@ocamlformat "disable"]
 end

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -286,7 +286,7 @@ module Make (Flow : Flow.S) (Runtime : S) = struct
           Log.debug (fun m -> m ~tags "Connection closed");
           let _ = Miou.Computation.try_cancel u_rd (Miou.Cancelled, empty_bt) in
           let _ = Miou.Computation.try_cancel u_wr (Miou.Cancelled, empty_bt) in
-          ()
+          if !s_rd = false || !s_wr = false then shutdown flow `read_write
         end
       in
       let orphans = Miou.orphans () in


### PR DESCRIPTION
This patch is more related to our project [`contruno`](https://github.com/robur-coop/contruno) where we noticed several times a busy-loop on the `terminate` function (because a task is suspended on the `Flow.recv` and will never end). A way to fix it is to force to shutdown the underlying connection. It is a draft and we must look up the implication of this PR with our current stack (`vif`, `hurl`, etc.)