### PR TITLE
Close fixes

### DIFF
--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -305,6 +305,10 @@ let listen_to_fd backlog = function
       Miou_unix.bind_and_listen ?backlog fd sockaddr;
       (fd, sockaddr)
 
+let we_bound = function
+  | Use _ -> false
+  | Bind _ -> true
+
 let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) ?upgrade
     ~handler:user's_handler listen =
@@ -325,7 +329,7 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Log.debug (fun m ->
             m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        if Atomic.compare_and_set closed false true then
+        if we_bound listen && Atomic.compare_and_set closed false true then
           Miou_unix.close file_descr
       end
     | Some (fd', client'sockaddr) ->
@@ -374,7 +378,7 @@ let with_tls ?(parallel = true) ?stop
         Log.debug (fun m ->
             m "Stopping service on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        if Atomic.compare_and_set closed false true then
+        if we_bound listen && Atomic.compare_and_set closed false true then
           Miou_unix.close file_descr
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -305,15 +305,12 @@ let listen_to_fd backlog = function
       Miou_unix.bind_and_listen ?backlog fd sockaddr;
       (fd, sockaddr)
 
-let we_bound = function
-  | Use _ -> false
-  | Bind _ -> true
+let we_bound = function Use _ -> false | Bind _ -> true
 
 let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) ?upgrade
     ~handler:user's_handler listen =
   let domains = Miou.Domain.available () in
-  let closed = Atomic.make false in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
     else ignore (Miou.async ~orphans fn)
@@ -329,8 +326,7 @@ let clear ?(parallel = true) ?stop ?(config = H1.Config.default) ?backlog ?ready
         Log.debug (fun m ->
             m "stop the server on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        if we_bound listen && Atomic.compare_and_set closed false true then
-          Miou_unix.close file_descr
+        if we_bound listen then Miou_unix.close file_descr
       end
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
@@ -361,7 +357,6 @@ let with_tls ?(parallel = true) ?stop
     ?(config = `Both (H1.Config.default, H2.Config.default)) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) tls_config
     ?upgrade ~handler:user's_handler listen =
-  let closed = Atomic.make false in
   let domains = Miou.Domain.available () in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
@@ -378,8 +373,7 @@ let with_tls ?(parallel = true) ?stop
         Log.debug (fun m ->
             m "Stopping service on %a" pp_sockaddr server'sockaddr);
         Runtime.terminate orphans;
-        if we_bound listen && Atomic.compare_and_set closed false true then
-          Miou_unix.close file_descr
+        if we_bound listen then Miou_unix.close file_descr
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);

--- a/src/http_miou_server.ml
+++ b/src/http_miou_server.ml
@@ -357,6 +357,7 @@ let with_tls ?(parallel = true) ?stop
     ?(config = `Both (H1.Config.default, H2.Config.default)) ?backlog ?ready
     ?error_handler:(user's_error_handler = default_error_handler) tls_config
     ?upgrade ~handler:user's_handler listen =
+  let closed = Atomic.make false in
   let domains = Miou.Domain.available () in
   let call ~orphans fn =
     if parallel && domains >= 2 then ignore (Miou.call ~orphans fn)
@@ -370,10 +371,11 @@ let with_tls ?(parallel = true) ?stop
         Miou.yield ();
         go orphans file_descr server'sockaddr
     | None ->
-        Runtime.terminate orphans;
-        Miou_unix.close file_descr;
         Log.debug (fun m ->
-            m "Stopping service on %a" pp_sockaddr server'sockaddr)
+            m "Stopping service on %a" pp_sockaddr server'sockaddr);
+        Runtime.terminate orphans;
+        if Atomic.compare_and_set closed false true then
+          Miou_unix.close file_descr
     | Some (fd', client'sockaddr) ->
         let socket = Miou_unix.to_file_descr fd' in
         inhibit (fun () -> Unix.setsockopt socket Unix.TCP_NODELAY true);

--- a/src/http_miou_server.mli
+++ b/src/http_miou_server.mli
@@ -58,9 +58,10 @@ type listen =
   | Use of Miou_unix.file_descr * Unix.sockaddr
       (** Controls whether or not [httpcats] binds its own listening socket or
           simply handles the file descriptor it was handed. In the latter case,
-          it is the responsibility of the caller to ensure the socket is bound
-          and listening, and the provided {!Unix.sockaddr} is only used for
-          logging. *)
+          the provided {!Unix.sockaddr} is only used for logging, and it is the
+          responsibility of the caller to manage the state of the file
+          descriptor. It must be ready for {!Miou_unix.accept} when passed in,
+          and closed with {!Miou_unix.close} after the server terminates. *)
 
 type error_handler =
   [ `V1 | `V2 ] -> ?request:request -> error -> (Headers.t -> body) -> unit


### PR DESCRIPTION
propagate the close fixes to TLS, but also only close the socket if we were the one to create and bind it. other passed-in sockets should be the responsibility of the creator to close.